### PR TITLE
Enable parallel iteration with rayon

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ exclude = ["assets/*"]
 equivalent = "1"
 seize = "0.5"
 serde = { version = "1", optional = true }
+rayon = { version = "1", optional = true }
 
 [dev-dependencies]
 rand = "0.8"
@@ -30,6 +31,7 @@ serde_json = "1"
 [features]
 default = []
 serde = ["dep:serde"]
+rayon = ["dep:rayon"]
 
 [profile.test]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,7 @@ harness = false
 [[bench]]
 name = "latency"
 harness = false
+
+[[bench]]
+name = "par_iter"
+harness = false

--- a/benches/par_iter.rs
+++ b/benches/par_iter.rs
@@ -1,0 +1,40 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use papaya::HashMap;
+use seize::Collector;
+
+#[cfg(feature = "rayon")]
+use rayon::prelude::*;
+
+const SIZE: usize = 100_000;
+
+fn par_vs_iter(c: &mut Criterion) {
+    let map = HashMap::<usize, usize>::builder()
+        .collector(Collector::new())
+        .build();
+    for i in 0..SIZE {
+        map.pin().insert(i, i);
+    }
+
+    let map_ref = map.pin_owned();
+
+    let mut group = c.benchmark_group("par_iter");
+    group.bench_function("iter", |b| {
+        b.iter(|| {
+            let sum: usize = map_ref.iter().map(|(_, &v)| v).sum();
+            black_box(sum);
+        })
+    });
+
+    #[cfg(feature = "rayon")]
+    group.bench_function("par_iter", |b| {
+        b.iter(|| {
+            let sum: usize = map_ref.par_iter().map(|(_, &v)| v).sum();
+            black_box(sum);
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, par_vs_iter);
+criterion_main!(benches);

--- a/src/map.rs
+++ b/src/map.rs
@@ -8,6 +8,7 @@ use std::fmt;
 use std::hash::{BuildHasher, Hash};
 use std::marker::PhantomData;
 
+
 /// A concurrent hash table.
 ///
 /// Most hash table operations require a [`Guard`](crate::Guard), which can be acquired through
@@ -1527,6 +1528,15 @@ where
         }
     }
 
+    /// Returns a parallel iterator over all key-value pairs.
+    ///
+    /// Requires the `rayon` feature.
+    #[cfg(feature = "rayon")]
+    #[inline]
+    pub fn par_iter(&self) -> raw::ParIter<'_, K, V, MapGuard<G>> {
+        self.map.raw.par_iter(&self.guard)
+    }
+
     /// An iterator visiting all keys in arbitrary order.
     /// The iterator element type is `&K`.
     ///
@@ -1569,6 +1579,22 @@ where
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, K, V, S, G> rayon::iter::IntoParallelIterator for &'a HashMapRef<'_, K, V, S, G>
+where
+    K: Hash + Eq + Sync,
+    V: Sync,
+    S: BuildHasher,
+    G: Guard + Sync,
+{
+    type Item = (&'a K, &'a V);
+    type Iter = raw::ParIter<'a, K, V, MapGuard<G>>;
+
+    fn into_par_iter(self) -> Self::Iter {
+        self.map.raw.par_iter(&self.guard)
     }
 }
 

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -7,6 +7,8 @@ use std::hash::{BuildHasher, Hash};
 use std::mem::MaybeUninit;
 use std::sync::atomic::{AtomicPtr, AtomicU8, AtomicUsize, Ordering};
 use std::sync::Mutex;
+#[cfg(feature = "rayon")]
+use std::fmt;
 use std::{hint, panic, ptr};
 
 use self::alloc::{RawTable, Table};
@@ -1229,6 +1231,35 @@ where
         let table = self.linearize(root, guard);
 
         Iter { i: 0, guard, table }
+    }
+
+    /// Returns a parallel iterator over all key/value pairs in the table.
+    #[cfg(feature = "rayon")]
+    #[inline]
+    pub fn par_iter<'g, G>(&self, guard: &'g G) -> ParIter<'g, K, V, G>
+    where
+        G: VerifiedGuard,
+    {
+        let root = self.root(guard);
+
+        if root.raw.is_null() {
+            return ParIter {
+                start: 0,
+                end: 0,
+                guard,
+                table: root,
+            };
+        }
+
+        let table = self.linearize(root, guard);
+        let len = table.len();
+
+        ParIter {
+            start: 0,
+            end: len,
+            guard,
+            table,
+        }
     }
 
     /// Returns the h1 and h2 hash for the given key.
@@ -2715,6 +2746,118 @@ impl<K, V, G> Clone for Iter<'_, K, V, G> {
             table: self.table,
             guard: self.guard,
         }
+    }
+}
+
+#[cfg(feature = "rayon")]
+/// A parallel iterator over the entries of a hash table.
+#[cfg(feature = "rayon")]
+pub struct ParIter<'g, K, V, G> {
+    start: usize,
+    end: usize,
+    table: Table<Entry<K, V>>,
+    guard: &'g G,
+}
+
+#[cfg(feature = "rayon")]
+impl<'g, K, V, G> fmt::Debug for ParIter<'g, K, V, G> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ParIter").finish()
+    }
+}
+
+#[cfg(feature = "rayon")]
+unsafe impl<K, V, G> Send for ParIter<'_, K, V, G>
+where
+    K: Sync,
+    V: Sync,
+    G: Sync,
+{
+}
+
+#[cfg(feature = "rayon")]
+unsafe impl<K, V, G> Sync for ParIter<'_, K, V, G>
+where
+    K: Sync,
+    V: Sync,
+    G: Sync,
+{
+}
+
+#[cfg(feature = "rayon")]
+impl<'g, K, V, G> rayon::iter::ParallelIterator for ParIter<'g, K, V, G>
+where
+    K: Sync + 'g,
+    V: Sync + 'g,
+    G: VerifiedGuard + Sync,
+{
+    type Item = (&'g K, &'g V);
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: rayon::iter::plumbing::UnindexedConsumer<Self::Item>,
+    {
+        rayon::iter::plumbing::bridge_unindexed(self, consumer)
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl<'g, K, V, G> rayon::iter::plumbing::UnindexedProducer for ParIter<'g, K, V, G>
+where
+    K: Sync + 'g,
+    V: Sync + 'g,
+    G: VerifiedGuard + Sync,
+{
+    type Item = (&'g K, &'g V);
+
+    fn split(mut self) -> (Self, Option<Self>) {
+        let len = self.end - self.start;
+        if len <= 1 {
+            (self, None)
+        } else {
+            let mid = self.start + len / 2;
+            let right = ParIter {
+                start: mid,
+                end: self.end,
+                table: self.table,
+                guard: self.guard,
+            };
+            self.end = mid;
+            (self, Some(right))
+        }
+    }
+
+    fn fold_with<F>(self, mut folder: F) -> F
+    where
+        F: rayon::iter::plumbing::Folder<Self::Item>,
+    {
+        if self.table.raw.is_null() {
+            return folder;
+        }
+        let mut i = self.start;
+        while i < self.end {
+            // Safety: i is in-bounds for the table length.
+            let meta = unsafe { self.table.meta(i) }.load(Ordering::Acquire);
+            if matches!(meta, meta::EMPTY | meta::TOMBSTONE) {
+                i += 1;
+                continue;
+            }
+
+            let entry = self
+                .guard
+                .protect(unsafe { self.table.entry(i) }, Ordering::Acquire)
+                .unpack();
+
+            if entry.ptr.is_null() {
+                i += 1;
+                continue;
+            }
+
+            let entry_ref = unsafe { &(*entry.ptr) };
+            folder = folder.consume((&entry_ref.key, &entry_ref.value));
+            i += 1;
+        }
+        folder
     }
 }
 

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -2762,9 +2762,13 @@ pub struct ParIter<'g, K, V, G> {
 #[cfg(feature = "rayon")]
 impl<'g, K, V, G> fmt::Debug for ParIter<'g, K, V, G> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ParIter").finish()
+        f.debug_struct("ParIter")
+            .field("start", &self.start)
+            .field("end", &self.end)
+            .finish()
     }
 }
+
 
 #[cfg(feature = "rayon")]
 unsafe impl<K, V, G> Send for ParIter<'_, K, V, G>

--- a/src/raw/utils/mod.rs
+++ b/src/raw/utils/mod.rs
@@ -7,12 +7,19 @@ pub use counter::Counter;
 pub use parker::Parker;
 pub use stack::Stack;
 pub use tagged::{untagged, AtomicPtrFetchOps, StrictProvenance, Tagged, Unpack};
+use std::fmt;
 
 /// A `seize::Guard` that has been verified to belong to a given map.
 pub trait VerifiedGuard: seize::Guard {}
 
 #[repr(transparent)]
 pub struct MapGuard<G>(G);
+
+impl<G> fmt::Debug for MapGuard<G> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MapGuard").finish()
+    }
+}
 
 impl<G> MapGuard<G> {
     /// Create a new `MapGuard`.

--- a/src/raw/utils/mod.rs
+++ b/src/raw/utils/mod.rs
@@ -8,6 +8,7 @@ pub use parker::Parker;
 pub use stack::Stack;
 pub use tagged::{untagged, AtomicPtrFetchOps, StrictProvenance, Tagged, Unpack};
 use std::fmt;
+use seize::Guard as _;
 
 /// A `seize::Guard` that has been verified to belong to a given map.
 pub trait VerifiedGuard: seize::Guard {}
@@ -15,11 +16,17 @@ pub trait VerifiedGuard: seize::Guard {}
 #[repr(transparent)]
 pub struct MapGuard<G>(G);
 
-impl<G> fmt::Debug for MapGuard<G> {
+impl<G> fmt::Debug for MapGuard<G>
+where
+    G: seize::Guard,
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("MapGuard").finish()
+        f.debug_struct("MapGuard")
+            .field("thread_id", &self.thread_id())
+            .finish()
     }
 }
+
 
 impl<G> MapGuard<G> {
     /// Create a new `MapGuard`.

--- a/src/set.rs
+++ b/src/set.rs
@@ -833,6 +833,17 @@ where
             raw: self.set.raw.iter(&self.guard),
         }
     }
+
+    /// Returns a parallel iterator over all values in arbitrary order.
+    ///
+    /// Requires the `rayon` feature.
+    #[cfg(feature = "rayon")]
+    #[inline]
+    pub fn par_iter(&self) -> ParIter<'_, K, G> {
+        ParIter {
+            inner: self.set.raw.par_iter(&self.guard),
+        }
+    }
 }
 
 impl<K, S, G> fmt::Debug for HashSetRef<'_, K, S, G>
@@ -860,11 +871,57 @@ where
     }
 }
 
+#[cfg(feature = "rayon")]
+impl<'a, K, S, G> rayon::iter::IntoParallelIterator for &'a HashSetRef<'_, K, S, G>
+where
+    K: Hash + Eq + Sync,
+    S: BuildHasher,
+    G: Guard + Sync,
+{
+    type Item = &'a K;
+    type Iter = ParIter<'a, K, G>;
+
+    fn into_par_iter(self) -> Self::Iter {
+        ParIter {
+            inner: self.set.raw.par_iter(&self.guard),
+        }
+    }
+}
+
 /// An iterator over a set's entries.
 ///
 /// This struct is created by the [`iter`](HashSet::iter) method on [`HashSet`]. See its documentation for details.
 pub struct Iter<'g, K, G> {
     raw: raw::Iter<'g, K, (), MapGuard<G>>,
+}
+
+#[cfg(feature = "rayon")]
+/// A parallel iterator over a set's entries.
+pub struct ParIter<'g, K, G> {
+    inner: raw::ParIter<'g, K, (), MapGuard<G>>,
+}
+
+#[cfg(feature = "rayon")]
+impl<'g, K, G> rayon::iter::ParallelIterator for ParIter<'g, K, G>
+where
+    K: Sync + 'g,
+    G: Guard + Sync,
+{
+    type Item = &'g K;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: rayon::iter::plumbing::UnindexedConsumer<Self::Item>,
+    {
+        self.inner.map(|(k, _)| k).drive_unindexed(consumer)
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl<'g, K, G> fmt::Debug for ParIter<'g, K, G> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ParIter").finish()
+    }
 }
 
 impl<'g, K: 'g, G> Iterator for Iter<'g, K, G>

--- a/src/set.rs
+++ b/src/set.rs
@@ -902,6 +902,13 @@ pub struct ParIter<'g, K, G> {
 }
 
 #[cfg(feature = "rayon")]
+impl<'g, K, G> fmt::Debug for ParIter<'g, K, G> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("ParIter").field(&self.inner).finish()
+    }
+}
+
+#[cfg(feature = "rayon")]
 impl<'g, K, G> rayon::iter::ParallelIterator for ParIter<'g, K, G>
 where
     K: Sync + 'g,
@@ -917,12 +924,6 @@ where
     }
 }
 
-#[cfg(feature = "rayon")]
-impl<'g, K, G> fmt::Debug for ParIter<'g, K, G> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ParIter").finish()
-    }
-}
 
 impl<'g, K: 'g, G> Iterator for Iter<'g, K, G>
 where

--- a/tests/rayon_iter.rs
+++ b/tests/rayon_iter.rs
@@ -1,0 +1,68 @@
+#![cfg(feature = "rayon")]
+
+use rayon::prelude::*;
+
+mod common;
+use common::{with_map, with_set};
+
+#[test]
+fn hashmap_par_iter() {
+    if cfg!(papaya_stress) {
+        return;
+    }
+    with_map::<usize, usize>(|map| {
+        let map = map();
+        let len = if cfg!(miri) { 100 } else { 10_000 };
+        for i in 0..len {
+            map.pin_owned().insert(i, i + 1);
+        }
+
+        let mut expected: Vec<_> = (0..len).map(|i| (i, i + 1)).collect();
+
+        let mut got: Vec<_> = map
+            .pin_owned()
+            .par_iter()
+            .map(|(&k, &v)| (k, v))
+            .collect();
+        got.sort();
+        expected.sort();
+        assert_eq!(expected, got);
+
+        let mut via_trait: Vec<_> = (&map.pin_owned())
+            .into_par_iter()
+            .map(|(&k, &v)| (k, v))
+            .collect();
+        via_trait.sort();
+        assert_eq!(expected, via_trait);
+    });
+}
+
+#[test]
+fn hashset_par_iter() {
+    if cfg!(papaya_stress) {
+        return;
+    }
+    with_set::<usize>(|set| {
+        let set = set();
+        let len = if cfg!(miri) { 100 } else { 10_000 };
+        for i in 0..len {
+            set.pin_owned().insert(i);
+        }
+
+        let mut expected: Vec<_> = (0..len).collect();
+
+        let mut got: Vec<_> = set
+            .pin_owned()
+            .par_iter()
+            .copied()
+            .collect();
+        got.sort();
+        expected.sort();
+        assert_eq!(expected, got);
+
+        let mut via_trait: Vec<_> = (&set.pin_owned()).into_par_iter().copied().collect();
+        via_trait.sort();
+        assert_eq!(expected, via_trait);
+    });
+}
+


### PR DESCRIPTION
## Summary
- add optional rayon dependency
- expose a `rayon` feature in Cargo
- implement a fast custom `ParIter` for `HashMapRef`
- extend parallel iterator utilities to `HashSetRef`
- add tests for rayon-based parallel iterators

## Testing
- `cargo test`
- `cargo test --features rayon`


------
https://chatgpt.com/codex/tasks/task_e_684e0d8ecfdc832f931f7d866504166b